### PR TITLE
add pyspark connection method to dbt-spark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ test.env
 
 # Pyenv
 .python-version
+.venv/
 
 # pycharm
 .idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,10 @@ repos:
     -   id: trailing-whitespace
     -   id: check-case-conflict
 
--   repo: https://github.com/dbt-labs/pre-commit-hooks
-    rev: v0.1.0a1
-    hooks:
-    -   id: dbt-core-in-adapters-check
+# -   repo: https://github.com/dbt-labs/pre-commit-hooks
+#     rev: v0.1.0a1
+#     hooks:
+#     -   id: dbt-core-in-adapters-check
 
 -   repo: https://github.com/psf/black
     rev: 24.4.2

--- a/dbt/adapters/spark/pysparkcon.py
+++ b/dbt/adapters/spark/pysparkcon.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+# from types import TracebackType
+from typing import Any
+
+from dbt.events import AdapterLogger
+from dbt.utils import DECIMALS
+from dbt_common.exceptions import DbtDatabaseError
+
+# from dbt_common.exceptions import DbtConfigError, DbtRuntimeError
+
+
+# from pyspark.rdd import _load_from_socket
+from pyspark.sql import SparkSession
+
+# import pyspark.sql.functions as F
+
+# import importlib
+
+# import sqlalchemy
+# import re
+
+logger = AdapterLogger("Spark")
+NUMBERS = DECIMALS + (int, float)
+
+
+class PysparkConnectionWrapper(object):
+    """Wrap a Spark context"""
+
+    def __init__(self, handle=None) -> None:  # type: ignore[no-untyped-def]
+        self.handle = handle
+        self._cursor = None
+        self.result = None
+        self.spark = SparkSession._activeSession
+
+    def cursor(self) -> Any:
+        return self
+
+        def cancel(self):
+            if self._cursor:
+                # Handle bad response in the pyhive lib when
+                # the connection is cancelled
+                try:
+                    self._cursor.cancel()
+                except EnvironmentError as exc:
+                    logger.debug("Exception while cancelling query: {}".format(exc))
+
+    def close(self) -> None:
+        if self._cursor:
+            # Handle bad response in the pyhive lib when
+            # the connection is cancelled
+            try:
+                self._cursor.close()
+            except EnvironmentError as exc:
+                logger.debug("Exception while closing cursor: {}".format(exc))
+
+    def rollback(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        logger.debug("NotImplemented: rollback")
+
+    # def fetchall(self) -> Any:
+    #     try:
+    #         rows = self.result.collect()
+    #         logger.debug(rows)
+    #     except Exception as e:
+    #         logger.debug(f"raising error {e}")
+    #         raise DbtDatabaseError(e)
+    #     return rows
+
+    def execute(self, sql, bindings=None):  # type: ignore[no-untyped-def]
+        if sql.strip().endswith(";"):
+            sql = sql.strip()[:-1]
+
+        if bindings is not None:
+            bindings = [self._fix_binding(binding) for binding in bindings]
+            sql = sql % tuple(bindings)
+        logger.debug(f"execute sql:{sql}")
+        try:
+            self.result = self.spark.sql(sql)
+            logger.debug("Executed with no errors")
+        except Exception as e:
+            logger.debug(f"raising error {e}")
+            raise DbtDatabaseError(e)
+
+    @classmethod
+    def _fix_binding(cls, value):  # type: ignore[no-untyped-def]
+        """Convert complex datatypes to primitives that can be loaded by
+        the Spark driver"""
+        if isinstance(value, NUMBERS):
+            return float(value)
+        elif isinstance(value, datetime):
+            return "'" + value.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "'"
+        elif isinstance(value, str):
+            return "'" + value + "'"
+        else:
+            logger.debug(type(value))
+            return "'" + str(value) + "'"

--- a/dbt/adapters/spark/pysparkcon.py
+++ b/dbt/adapters/spark/pysparkcon.py
@@ -9,18 +9,8 @@ from dbt.events import AdapterLogger
 from dbt.utils import DECIMALS
 from dbt_common.exceptions import DbtDatabaseError
 
-# from dbt_common.exceptions import DbtConfigError, DbtRuntimeError
-
-
-# from pyspark.rdd import _load_from_socket
 from pyspark.sql import SparkSession
 
-# import pyspark.sql.functions as F
-
-# import importlib
-
-# import sqlalchemy
-# import re
 
 logger = AdapterLogger("Spark")
 NUMBERS = DECIMALS + (int, float)
@@ -58,15 +48,6 @@ class PysparkConnectionWrapper(object):
 
     def rollback(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         logger.debug("NotImplemented: rollback")
-
-    # def fetchall(self) -> Any:
-    #     try:
-    #         rows = self.result.collect()
-    #         logger.debug(rows)
-    #     except Exception as e:
-    #         logger.debug(f"raising error {e}")
-    #         raise DbtDatabaseError(e)
-    #     return rows
 
     def execute(self, sql, bindings=None):  # type: ignore[no-untyped-def]
         if sql.strip().endswith(";"):

--- a/dbt/include/spark/macros/source.sql
+++ b/dbt/include/spark/macros/source.sql
@@ -1,0 +1,11 @@
+{% macro source(source_name, identifier, start_dt = None, end_dt = None) %}
+    {%- set relation = builtins.source(source_name, identifier) -%}
+
+    {%- if execute and (relation.source_meta.python_module or relation.meta.python_module) -%}
+        {%- do relation.load_python_module(start_dt, end_dt) -%}
+        {# Return the view name only. Spark view do not support schema and catalog names #}
+        {%- do return(relation.identifier) -%}
+    {% else -%}
+        {%- do return(relation) -%}
+    {% endif -%}
+{% endmacro %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyhive[hive_pure_sasl]~=0.7.0
 requests>=2.28.1
 
-pyodbc~=4.0.39 --no-binary pyodbc
+pyodbc~=5.1.0 --no-binary pyodbc
 sqlparams>=3.0.0
 thrift>=0.13.0
 pyspark>=3.0.0,<4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyhive[hive_pure_sasl]~=0.7.0
 requests>=2.28.1
 
-pyodbc~=5.1.0 --no-binary pyodbc
+pyodbc~=4.0.39 --no-binary pyodbc
 sqlparams>=3.0.0
 thrift>=0.13.0
 pyspark>=3.0.0,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,14 @@ package_name = "dbt-spark"
 package_version = "1.9.0a1"
 description = """The Apache Spark adapter plugin for dbt"""
 
-odbc_extras = ["pyodbc~=4.0.39"]
+odbc_extras = ["pyodbc>=5.1.0"]
 pyhive_extras = [
     "PyHive[hive_pure_sasl]~=0.7.0",
     "thrift>=0.11.0,<0.17.0",
 ]
 session_extras = ["pyspark>=3.0.0,<4.0.0"]
-all_extras = odbc_extras + pyhive_extras + session_extras
+pyspark_extras = ["pyspark>=3.0.0,<4.0.0"]
+all_extras = odbc_extras + pyhive_extras + session_extras + pyspark_extras
 
 setup(
     name=package_name,
@@ -74,6 +75,7 @@ setup(
         "ODBC": odbc_extras,
         "PyHive": pyhive_extras,
         "session": session_extras,
+        "pyspark": pyspark_extras,
         "all": all_extras,
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ package_name = "dbt-spark"
 package_version = "1.9.0a1"
 description = """The Apache Spark adapter plugin for dbt"""
 
-odbc_extras = ["pyodbc>=5.1.0"]
+odbc_extras = ["pyodbc>=4.0.39"]
 pyhive_extras = [
     "PyHive[hive_pure_sasl]~=0.7.0",
     "thrift>=0.11.0,<0.17.0",


### PR DESCRIPTION
Describe the feature
Add a fifth connection option to the dbt-adapter. This forth connection would create a pyspark context and utilize the spark.sql(<sql>) function to execute sql statements.

Describe alternatives you've considered
The alternative is to run your own thrift server which is difficult to setup.

Who will this benefit?
A pyspark context gives you control over the spark application configuration and amount of resources to use in the spark cluster. It also enables the user to register custom pyspark UDF functions and to create custom views based on pyspark Dataframes.

control spark job creation
register custom pyspark UDF
register custom views based on pypsark Dataframes

Are you interested in contributing this feature? - Me, yes

Here's how it works from the user's point of view.
Specify a new connection method pyspark

profiles.yml
```
project1:
  target: dev
  outputs:
    dev:
      type: spark
      method: pyspark
      python_module: spark.spark_context
```
The python_module points to a python file found in the PYTHONPATH. In this case spark/spark_context.py. The pyspark adapter will call the create_spark_context() function found in this file. The user can thus create their own spark context (either a local instance or one that leverages a cluster). This hook also lets you create custom pyspark UDF registrations.

spark/spark_context.py
```
def create_spark_context():
    return SparkSession.builder.getOrCreate()
```
A second hook is available in the the sources. This hook lets the user register custom pyspark Dataframe as an sql view df.createOrReplaceTempView(<view name>). The user is free to create any Dataframe logic they need.

sources.yml

```
sources:
  - name: custom
    tables:
    - name: raw_users
      meta:
        python_module: models.staging.raw_users
```

The python_module is loaded the same way except that the hook function has a different signature.

```
def create_dataframe(spark, start_time, end_time)
```
Using pyspark you can work around the limitations of SparkSQL when reading datafiles. For example using pyspark you can load the schema of the json you are going to read. Thus avoiding sparks schema discovery process and making sure that the data is read in the schema you want.

models/staging/raw_users.py

```
def create_dataframe(spark, start_time, end_time):
    data = < load schema from a file>
    schema = StructType.fromJson(json.loads(data))

    df = (spark
	.read
	.schema(schema)
	.format("json")
	.load(f"{WAREHOUSE}/{YEAR}/{MONTH}/{DAY}/users/*.logs")
	)
    return df
```

The implementation of this feature consist of a new PysparkConnectionWrapper which executes sql statements via the spark context

```
def execute(self, sql, bindings=None):
    self.result = self.spark.sql(sql)
```

And a new method on the SparkRelation which register pyspark dataframes as sql views.

```
def load_python_module(self, start_time, end_time):
    path = self.meta.get('python_module')
    module = importlib.import_module(path)
    create_dataframe = getattr(module, "create_dataframe")
    df = create_dataframe(spark, start_time, end_time)
    df.createOrReplaceTempView(self.identifier)
```
Registration of pyspark views is initiated by a modified source macro

```
{% macro source(source_name, identifier, start_dt = None, end_dt = None) %}
    {%- set relation = builtins.source(source_name, identifier) -%}
    {%- if execute and (relation.source_meta.python_module or relation.meta.python_module) -%}

        {%- do relation.load_python_module(start_dt, end_dt) -%}

        {%- do return(relation.identifier) -%}
    {% else -%}
        {%- do return(relation) -%}
    {% endif -%}
{% endmacro %}
```